### PR TITLE
Smaller container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:19.3-bullseye-slim
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
 
+HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1
+
 EXPOSE 5656
 # Run your program under Tini
 CMD ["node", "server.js", "config.json", "-i DATAROOT/*", "-i ASSETS/*"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ curl -sL https://github.com/TuomoKu/SPX-GC/archive/refs/tags/v.1.1.2.tar.gz | ta
 * Build the container:
 
 ```sh
-docker build -t spx-v1.1.2 .
+docker build -t spx .
 ```
 
 ## Running the container
@@ -19,5 +19,5 @@ docker build -t spx-v1.1.2 .
 * Default port for the web gui in plain http is `5656`.
 
 ```sh
-docker run -p 5656:5656 -v /home/ubuntu/projektit/SPX-GC-v.1.1.2/config.json:/usr/src/app/config.json spx-v1.1.2
+docker run --name spx -p 5656:5656 -v /home/ubuntu/projektit/SPX-GC-v.1.1.2/config.json:/usr/src/app/config.json spx
 ```


### PR DESCRIPTION
- Changed to smaller base image, decreased container size from 995 MB to 341 MB. 
- Added HEALTHCHECK (though it doesn't seem to work at the moment:

`CONTAINER ID   IMAGE     COMMAND                  CREATED         STATUS                     PORTS                                       NAMES`
`0586bbe250cc   spx       "/tini -- node serve…"   2 minutes ago   Up 2 minutes (unhealthy)   0.0.0.0:5656->5656/tcp, :::5656->5656/tcp   spx`